### PR TITLE
Text display fix

### DIFF
--- a/Xml/items.xml
+++ b/Xml/items.xml
@@ -1,29 +1,134 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Items>
   <!-- longer text labels -->
-  <Item name="" identifier="mb_textdisplay2" nameidentifier="textdisplay" scale="0.5" variantof="textdisplay">
+  <Item nameidentifier="textdisplay" identifier="mb_textdisplay2" category="Electrical" scale="0.5" Tags="mediumitem,logic" impactsoundtag="impact_metal_light" cargocontaineridentifier="metalcrate" isshootable="true">
+    <Upgrade gameversion="0.12.0.0" scale="0.5"/>
     <Sprite texture="%ModDir%/Images/labels.png" depth="0.85" sourcerect="0,0,256,48" />
+    <Price baseprice="200">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" />
+    </Price>
+    <PreferredContainer primary="reactorcab,engcab"/>
+    <Deconstruct time="10">
+      <Item identifier="copper" />
+      <Item identifier="tin" />
+      <Item identifier="silicon" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="30">
+      <RequiredSkill identifier="electrical" level="50" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="silicon" />
+    </Fabricate>
+    <Body width="120" height="40" density="20" />
     <ItemLabel scrollable="true" padding="10,5,10,12" textcolor="1,1,1,1">
-      <LightComponent range="10.0" lightcolor="1.0,1.0,1.0,0.1" IsOn="true" castshadows="false">
-        <sprite texture="%ModDir%/Images/labels.png" sourcerect="0,48,256,48" depth="0.025" origin="0.5,0.5" alpha="1.0" />
-      </LightComponent>
+      <Upgrade gameversion="0.12.0.0" padding="10,5,10,12"/>
     </ItemLabel>
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="%ModDir%/Images/labels.png" sourcerect="0,48,256,48" depth="0.025" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="ItemMsgDetachWrench" PickingTime="5.0" aimpos="65,-10" handle1="0,0" attachable="true" aimable="true" attachedbydefault="true">
+      <RequiredItem items="wrench" type="Equipped" />
+    </Holdable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel"/>
+      <requireditem items="screwdriver" type="Equipped"/>
+      <input name="set_text" displayname="connection.set_text" fallbackdisplayname="connection.setoutput"/>
+      <input name="set_color" displayname="connection.setcolor" />
+      <input name="set_text_color" displayname="connection.settextcolor" />
+    </ConnectionPanel>
   </Item>
-  <Item name="" identifier="mb_textdisplay3" nameidentifier="textdisplay" scale="0.5" variantof="textdisplay">
+  <Item nameidentifier="textdisplay" identifier="mb_textdisplay3" category="Electrical" scale="0.5" Tags="mediumitem,logic" impactsoundtag="impact_metal_light" cargocontaineridentifier="metalcrate" isshootable="true">
+    <Upgrade gameversion="0.12.0.0" scale="0.5"/>
     <Sprite texture="%ModDir%/Images/labels.png" depth="0.85" sourcerect="0,104,384,48" />
+    <Price baseprice="200">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" />
+    </Price>
+    <PreferredContainer primary="reactorcab,engcab"/>
+    <Deconstruct time="10">
+      <Item identifier="copper" />
+      <Item identifier="tin" />
+      <Item identifier="silicon" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="30">
+      <RequiredSkill identifier="electrical" level="50" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="silicon" />
+    </Fabricate>
+    <Body width="120" height="40" density="20" />
     <ItemLabel scrollable="true" padding="10,5,10,12" textcolor="1,1,1,1">
-      <LightComponent range="10.0" lightcolor="1.0,1.0,1.0,0.1" IsOn="true" castshadows="false">
-        <sprite texture="%ModDir%/Images/labels.png" sourcerect="0,152,384,48" depth="0.025" origin="0.5,0.5" alpha="1.0" />
-      </LightComponent>
+      <Upgrade gameversion="0.12.0.0" padding="10,5,10,12"/>
     </ItemLabel>
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="%ModDir%/Images/labels.png" sourcerect="0,152,384,48" depth="0.025" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="ItemMsgDetachWrench" PickingTime="5.0" aimpos="65,-10" handle1="0,0" attachable="true" aimable="true" attachedbydefault="true">
+      <RequiredItem items="wrench" type="Equipped" />
+    </Holdable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel"/>
+      <requireditem items="screwdriver" type="Equipped"/>
+      <input name="set_text" displayname="connection.set_text" fallbackdisplayname="connection.setoutput"/>
+      <input name="set_color" displayname="connection.setcolor" />
+      <input name="set_text_color" displayname="connection.settextcolor" />
+    </ConnectionPanel>
   </Item>
-  <Item name="" identifier="mb_textdisplay4" nameidentifier="textdisplay" scale="0.5" variantof="textdisplay">
+  <Item nameidentifier="textdisplay" identifier="mb_textdisplay4" category="Electrical" scale="0.5" Tags="mediumitem,logic" impactsoundtag="impact_metal_light" cargocontaineridentifier="metalcrate" isshootable="true">
+    <Upgrade gameversion="0.12.0.0" scale="0.5"/>
     <Sprite texture="%ModDir%/Images/labels.png" depth="0.85" sourcerect="0,211,512,48" />
+    <Price baseprice="200">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" multiplier="1.25" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+      <Price storeidentifier="merchantengineering" multiplier="0.9" />
+    </Price>
+    <PreferredContainer primary="reactorcab,engcab"/>
+    <Deconstruct time="10">
+      <Item identifier="copper" />
+      <Item identifier="tin" />
+      <Item identifier="silicon" />
+      <Item identifier="plastic" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="30">
+      <RequiredSkill identifier="electrical" level="50" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="tin" />
+      <RequiredItem identifier="silicon" />
+    </Fabricate>
+    <Body width="120" height="40" density="20" />
     <ItemLabel scrollable="true" padding="10,5,10,12" textcolor="1,1,1,1">
-      <LightComponent range="10.0" lightcolor="1.0,1.0,1.0,0.1" IsOn="true" castshadows="false">
-        <sprite texture="%ModDir%/Images/labels.png" sourcerect="0,259,512,48" depth="0.025" origin="0.5,0.5" alpha="1.0" />
-      </LightComponent>
+      <Upgrade gameversion="0.12.0.0" padding="10,5,10,12"/>
     </ItemLabel>
+    <LightComponent range="0.0" lightcolor="255,255,255,0" IsOn="true" castshadows="false">
+      <Upgrade gameversion="0.17.15.0" range="0" />
+      <sprite texture="%ModDir%/Images/labels.png" sourcerect="0,259,512,48" depth="0.025" origin="0.5,0.5" alpha="1.0" />
+    </LightComponent>
+    <Holdable selectkey="Select" pickkey="Use" slots="Any,RightHand,LeftHand" msg="ItemMsgDetachWrench" PickingTime="5.0" aimpos="65,-10" handle1="0,0" attachable="true" aimable="true" attachedbydefault="true">
+      <RequiredItem items="wrench" type="Equipped" />
+    </Holdable>
+    <ConnectionPanel selectkey="Action" canbeselected="true" msg="ItemMsgRewireScrewdriver" hudpriority="10">
+      <GuiFrame relativesize="0.2,0.32" minsize="400,350" maxsize="480,420" anchor="Center" style="ConnectionPanel"/>
+      <requireditem items="screwdriver" type="Equipped"/>
+      <input name="set_text" displayname="connection.set_text" fallbackdisplayname="connection.setoutput"/>
+      <input name="set_color" displayname="connection.setcolor" />
+      <input name="set_text_color" displayname="connection.settextcolor" />
+    </ConnectionPanel>
   </Item>
   <!-- containers -->
   <Item name="" nameidentifier="crateshelf" identifier="mb_crateshelf1" tags="container,cargocontainer" linkable="true" canflipx="false" pickdistance="150" scale="0.5">


### PR DESCRIPTION
Reported by discord member Ladripper#4787: Text displays in MB have two "LightComponent" and "IsOn" is always "true" when test in editor. 
"variantof" have a problem, I guess because one item can have more than one "LightComponent" 
Previously code just add another "LightComponent" in MB text display, not edit the "LightComponent". So I don't use variantof, and it works.